### PR TITLE
Some refactorings + proper error handling

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--require spec_helper
+--format doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+before_install:
+  - gem install bundler
+
 language: ruby
 rvm:
  - 1.9.3

--- a/README.md
+++ b/README.md
@@ -4,21 +4,32 @@ Status](https://travis-ci.org/johnewart/ruby-opentsdb.svg?branch=master)](https:
 
 ## What is this?
 
-This is a Ruby client for simplifying interactions with OpenTSDB
+This is a Ruby client for simplifying interactions with OpenTSDB.
 
 ## What does it do?
 
-As of this instant, not a whole lot except wrap the "put" method in a 
-quick-and-dirty style. This will eventually grow to be much more useful 
-as I expand functionality. 
+As of this instant, not a whole lot except wrap the "put" method in a
+quick-and-dirty style. This will eventually grow to be much more useful
+as I expand functionality.
+
+## Requirements
+
+ruby 1.9.3+
 
 ## Quick example
 
-    @client = OpenTSDB::Client.new({:hostname => 'localhost', :port => 4242})
+```ruby
+  @client = OpenTSDB::Client.new(hostname: 'localhost', port: 4242)
 
-    sample = { :metric => 'double_rainbow.count', :value => 42, :timestamp => Time.now.to_i, :tags => {:factor => 'awesome', :host => 'ponies' } }
-    @client.put(sample)
+  sample = {
+    metric: 'double_rainbow.count',
+    value: 42,
+    timestamp: Time.now.to_i,
+    tags: { factor: 'awesome', host: 'ponies' }
+  }
 
+  @client.put(sample)
+```
 
 ## License
 

--- a/examples/client.rb
+++ b/examples/client.rb
@@ -1,8 +1,12 @@
 require 'rubygems'
-$:.unshift File.dirname(__FILE__) + "/../lib"
+$:.unshift File.dirname(__FILE__) + '/../lib'
 require 'opentsdb'
 
-@client = OpenTSDB::Client.new({:hostname => 'localhost', :port => 4242})
+@client = OpenTSDB::Client.new(hostname: 'localhost', port: 4242)
 
-sample = { :metric => 'double_rainbow.count', :value => 42, :timestamp => Time.now.to_i, :tags => {:factor => 'awesome', :host => 'ponies' } }
+sample = {
+  metric: 'double_rainbow.count', value: 42, timestamp: Time.now.to_i,
+  tags: { factor: 'awesome', host: 'ponies' }
+}
+
 @client.put(sample)

--- a/lib/opentsdb.rb
+++ b/lib/opentsdb.rb
@@ -12,4 +12,5 @@ module OpenTSDB
   end
 end
 
+require 'opentsdb/errors'
 require 'opentsdb/client'

--- a/lib/opentsdb/client.rb
+++ b/lib/opentsdb/client.rb
@@ -8,25 +8,24 @@ module OpenTSDB
     attr_reader :connection
 
     def initialize(options = {})
-      begin
-        hostname = options[:hostname] || 'localhost'
-        port = options[:port] || 4242
-        @connection = TCPSocket.new(hostname, port)
-      rescue
-        raise "Unable to connect or invalid connection data"
-      end
+      hostname    = options[:hostname] || 'localhost'
+      port        = options[:port] || 4242
+      @connection = TCPSocket.new(hostname, port)
+    rescue
+      raise "Unable to connect or invalid connection data"
     end
 
-    def to_command( options )
-      timestamp = options[:timestamp].to_i
+    def to_command(options)
+      timestamp   = options[:timestamp].to_i
       metric_name = options[:metric]
-      value = options[:value].to_f
-      tags = options[:tags].map{|k,v| "#{k}=#{v}"}.join(" ")
+      value       = options[:value].to_f
+      tags        = options[:tags].map { |k, v| "#{k}=#{v}" }.join(' ')
+
       "put #{metric_name} #{timestamp} #{value} #{tags}"
     end
 
-    def build_command(input) 
-      if input.kind_of?(Array)
+    def build_command(input)
+      if input.is_a?(Array)
         input.collect { |unit| to_command(unit) }.join("\n")
       else
         to_command(input)

--- a/lib/opentsdb/client.rb
+++ b/lib/opentsdb/client.rb
@@ -12,7 +12,7 @@ module OpenTSDB
       port        = options[:port] || 4242
       @connection = TCPSocket.new(hostname, port)
     rescue
-      raise "Unable to connect or invalid connection data"
+      raise Errors::UnableToConnectError
     end
 
     def to_command(options)

--- a/lib/opentsdb/errors.rb
+++ b/lib/opentsdb/errors.rb
@@ -1,0 +1,9 @@
+module OpenTSDB
+  module Errors
+    class UnableToConnectError < StandardError
+      def to_s
+        'Unable to connect or invalid connection data'
+      end
+    end
+  end
+end

--- a/lib/opentsdb/version.rb
+++ b/lib/opentsdb/version.rb
@@ -1,3 +1,3 @@
 module OpenTSDB
-  VERSION = "0.2.0"
+  VERSION = '1.0.0'
 end

--- a/opentsdb.gemspec
+++ b/opentsdb.gemspec
@@ -1,25 +1,27 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "opentsdb/version"
+$:.push File.expand_path('../lib', __FILE__)
+require 'opentsdb/version'
 
 Gem::Specification.new do |s|
-  s.name        = "opentsdb"
+  s.name        = 'opentsdb'
   s.version     = OpenTSDB::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["John Ewart"]
-  s.email       = ["john@johnewart.net"]
-  s.homepage    = "https://github.com/johnewart/ruby-opentsdb"
-  s.summary     = %q{Ruby client for OpenTSDB}
-  s.description = %q{A Ruby implementation of a client library for sending data points to OpenTSDB}
+  s.authors     = ['John Ewart']
+  s.email       = ['john@johnewart.net']
+  s.homepage    = 'https://github.com/johnewart/ruby-opentsdb'
+  s.summary     = 'Ruby client for OpenTSDB'
+  s.description = 'A Ruby implementation of a client library for sending data points to OpenTSDB'
   s.license     = 'MIT'
 
-  s.rubyforge_project = "opentsdb"
+  s.rubyforge_project = 'opentsdb'
 
-  s.add_development_dependency "rspec"
-  s.add_development_dependency "simplecov", [">= 0.3.8"] #, :require => false
+  s.required_ruby_version = '>= 1.9.3'
+
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'simplecov', ['>= 0.3.8']
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.require_paths = ['lib']
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,45 +1,50 @@
 require 'spec_helper.rb'
 
 describe OpenTSDB::Client do
-  before :each do 
-    @socket = double('socket').as_null_object
-    expect(TCPSocket).to receive(:new).and_return(@socket)
-    @client = OpenTSDB::Client.new
-  end
-  
-  it "should create a new client" do  
+  let(:socket) { double('socket').as_null_object }
+  let(:client) { described_class.new }
+
+  before(:each) do
+    allow(TCPSocket).to receive(:new).and_return(socket)
   end
 
-  it "should write a single metric to the socket" do 
-    expect(@socket).to receive(:puts).with("put users 1411104988 100.0 foo=bar")
+  it 'creates a new client' do
+    expect { client }.to_not raise_error
+  end
+
+  it 'writes a single metric to the socket' do
+    expect(socket).to receive(:puts).with('put users 1411104988 100.0 foo=bar')
+
     metric = {
-      :timestamp => 1411104988,
-      :metric => "users",
-      :value => 100,
-      :tags => { :foo => "bar" }
-    }
-    @client.put(metric)
-  end
-
-  it "should write multiple metrics to the socket" do
-    expect(@socket).to receive(:puts).with("put users 1411104988 100.0 foo=bar\nput users 1411104999 150.0 bar=baz")
-    metrics = []
-    metrics << {
-      :timestamp => 1411104988,
-      :metric => "users",
-      :value => 100,
-      :tags => { :foo => "bar" }
+      timestamp: 1411104988,
+      metric: 'users',
+      value: 100,
+      tags: { foo: 'bar' },
     }
 
-    metrics << {
-      :timestamp => 1411104999,
-      :metric => "users",
-      :value => 150,
-      :tags => { :bar => "baz" }
-     }
-
-    @client.put(metrics)
-  
+    client.put(metric)
   end
-  
+
+  it 'writes multiple metrics to the socket' do
+    expect(socket).to receive(:puts).with(
+      "put users 1411104988 100.0 foo=bar\nput users 1411104999 150.0 bar=baz"
+    )
+
+    metrics = [
+      {
+        timestamp: 1411104988,
+        metric: 'users',
+        value: 100,
+        tags: { foo: 'bar' },
+      },
+      {
+        timestamp: 1411104999,
+        metric: 'users',
+        value: 150,
+        tags: { bar: 'baz' },
+      },
+    ]
+
+    client.put(metrics)
+  end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -8,6 +8,16 @@ describe OpenTSDB::Client do
     allow(TCPSocket).to receive(:new).and_return(socket)
   end
 
+  describe 'error handling' do
+    subject { described_class.new }
+
+    it 'raises a custom error if the connection failed' do
+      expect(TCPSocket).to receive(:new).and_raise('connection error')
+
+      expect { subject }.to raise_error(OpenTSDB::Errors::UnableToConnectError)
+    end
+  end
+
   it 'creates a new client' do
     expect { client }.to_not raise_error
   end


### PR DESCRIPTION
We depend on this gem for several things and we needed to do proper error handling of it. 

The problem was that [the error raised was a generic one](https://github.com/johnewart/ruby-opentsdb/blob/master/lib/opentsdb/client.rb#L16).

This pull request makes the code raise an `OpenTSDB::Errors::UnableToConnectError` exception.

Also, it gives some love to the codebase:

1. Rubocop refactors for newer ruby versions.
2. Styles refactors.